### PR TITLE
Include doc, examples and tests in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include NOTICE
 include *.rst
 include requirements.txt
 prune .DS_Store
+graft doc examples testdata tests


### PR DESCRIPTION
PR's text:
```
Hi,
We at Gentoo rely on PyPI tarballs to build docs and run tests. I understand that this means distributing a larger file.

It could also be beneficial to other distributions like Debian: https://lists.debian.org/debian-python/2016/04/msg00074.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/572)
<!-- Reviewable:end -->

```

link to original PR: `https://github.com/bear/python-twitter/pull/572`