### PR TITLE
Add documented but missing count to GetLists()

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4470,7 +4470,8 @@ class Api(object):
 
     def GetLists(self,
                  user_id=None,
-                 screen_name=None):
+                 screen_name=None,
+                 count=20):
         """Fetch the sequence of lists for a user. If no user_id or screen_name
         is passed, the data returned will be for the authenticated user.
 
@@ -4482,6 +4483,8 @@ class Api(object):
             for. [Optional]
           count:
             The amount of results to return per page.
+            Consider bumping this up if you are getting rate limit issues
+            with GetLists(), generally at > 15 * 20 = 300 lists.
             No more than 1000 results will ever be returned in a single page.
             Defaults to 20. [Optional]
           cursor:
@@ -4500,7 +4503,8 @@ class Api(object):
             next_cursor, prev_cursor, lists = self.GetListsPaged(
                 user_id=user_id,
                 screen_name=screen_name,
-                cursor=cursor)
+                cursor=cursor,
+                count=count)
             result += lists
             if next_cursor == 0 or next_cursor == prev_cursor:
                 break


### PR DESCRIPTION
PR's text:
```
The GetLists() method documents the count parameter,
which is actually not available in the method signature
and can't be used.

Due to this, the GetLists() method is basically limited to
retrieving ~300 lists at once, as the internally called
GetListsPaged() method will retrieve only 20 lists at once
and will hit rate limits after 15 calls in a row.

So add "count" to the method signature and pass it to
GetListsPaged(). Also add a note about rate limits & hint
to bump "count" once they start to be hit.

With this change a caller that passes say 500 as "count"
(tested) can retrieve 300+ lists without unnecessarily
hitting rate limits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/646)
<!-- Reviewable:end -->

```

link to original PR: `https://github.com/bear/python-twitter/pull/646`